### PR TITLE
Bug duplicate req

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ typings/
 .next
 
 ids.txt
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,3 @@ typings/
 .next
 
 ids.txt
-package-lock.json

--- a/brainclouds2s.js
+++ b/brainclouds2s.js
@@ -40,35 +40,29 @@ function s2sRequest(context, json, callback) {
             if (context.logEnabled) {
                 console.log(`[S2S RECV ${context.appId}] ${data}`)
             }
-            if (callback) {
-                if (data) {
+            if (data) {
 
-                    try {
-                        let dataJson = JSON.parse(data)
-                        callCallback(callback, context, dataJson)
-                    }
-                    catch (error) {
-                        if (context.logEnabled) {
-                            console.log(`[S2S Error ${context.appId}] ${error}`)
-                        }
-                        if (callback) {
-                            callCallback(callback, context, null)
-                        }
-                    }
-
+                try {
+                    let dataJson = JSON.parse(data)
+                    callCallback(callback, context, dataJson)
                 }
-                else {
+                catch (error) {
+                    if (context.logEnabled) {
+                        console.log(`[S2S Error ${context.appId}] ${error}`)
+                    }
                     callCallback(callback, context, null)
                 }
+
+            }
+            else {
+                callCallback(callback, context, null)
             }
         })
     }).on("error", err => {
         if (context.logEnabled) {
             console.log(`[S2S Error ${context.appId}] ${err.message}`)
         }
-        if (callback) {
-            callCallback(callback, context, null)
-        }
+        callCallback(callback, context, null)
     })
 
     // write data to request body
@@ -135,14 +129,12 @@ function authenticateInternal(context, callback) {
                 failAllRequests(context, message);
             }
 
-            if (callback)
-                callCallback(callback, context, message)
+            callCallback(callback, context, message)
         }
         else {
             failAllRequests(context, null);
             exports.disconnect(context)
-            if (callback)
-                callCallback(callback, context, null)
+            callCallback(callback, context, null)
         }
     })
 }
@@ -202,15 +194,13 @@ function request(context, json, callback) {
             return
         }
 
-        if (callback) {
-            if (data && data.messageResponses && data.messageResponses.length > 0) {
-                callCallback(callback, context, data.messageResponses[0])
-            }
-            else {
-                
-                // Error that has no packets
-                callCallback(callback, context, data)
-            }
+        if (data && data.messageResponses && data.messageResponses.length > 0) {
+            callCallback(callback, context, data.messageResponses[0])
+        }
+        else {
+            
+            // Error that has no packets
+            callCallback(callback, context, data)
         }
 
         // This request is complete and safe to remove from queue after checking for callback

--- a/brainclouds2s.js
+++ b/brainclouds2s.js
@@ -46,15 +46,14 @@ function s2sRequest(context, json, callback) {
                     responseData = JSON.parse(data);
                 }
                 catch (error) {
-                    console.log(`[S2S Error ${context.appId}] ${error}`)
-                    console.log("Failed to parse response");
+                    console.log(`[S2S Error parsing response data ${context.appId}] ${error}`)
                 }
             }
             callCallback(callback, context, responseData)
         })
     }).on("error", err => {
         if (context.logEnabled) {
-            console.log(`[S2S Error ${context.appId}] ${err.message}`)
+            console.log(`[S2S Error making request ${context.appId}] ${err.message}`)
         }
         callCallback(callback, context, null)
     })
@@ -197,7 +196,7 @@ function request(context, json, callback) {
             callCallback(callback, context, data)
         }
 
-        // This request is complete and safe to remove from queue after checking for callback
+        // This request is complete and safe to remove from queue after invoking callback
         context.requestQueue.splice(0, 1); // Remove this request from the queue
         context.retryCount = 0;
 
@@ -221,7 +220,7 @@ function callCallback(callback, context, data) {
             callback(context, data);
         }
         catch (error) {
-            console.log(`[S2S Error ${context.appId}] ${error}`)
+            console.log(`[S2S Callback Error ${context.appId}] ${error}`)
         }
     }
 }

--- a/brainclouds2s.js
+++ b/brainclouds2s.js
@@ -44,7 +44,7 @@ function s2sRequest(context, json, callback)
         {
             if (context.logEnabled)
             {
-                console.log(`[S2S ReCV ${context.appId}] ${data}`)
+                console.log(`[S2S RECV ${context.appId}] ${data}`)
             }
             if (callback)
             {

--- a/brainclouds2s.js
+++ b/brainclouds2s.js
@@ -40,23 +40,17 @@ function s2sRequest(context, json, callback) {
             if (context.logEnabled) {
                 console.log(`[S2S RECV ${context.appId}] ${data}`)
             }
+            let responseData = null;
             if (data) {
-
                 try {
-                    let dataJson = JSON.parse(data)
-                    callCallback(callback, context, dataJson)
+                    responseData = JSON.parse(data);
                 }
                 catch (error) {
-                    if (context.logEnabled) {
-                        console.log(`[S2S Error ${context.appId}] ${error}`)
-                    }
-                    callCallback(callback, context, null)
+                    console.log(`[S2S Error ${context.appId}] ${error}`)
+                    console.log("Failed to parse response");
                 }
-
             }
-            else {
-                callCallback(callback, context, null)
-            }
+            callCallback(callback, context, responseData)
         })
     }).on("error", err => {
         if (context.logEnabled) {

--- a/brainclouds2s.js
+++ b/brainclouds2s.js
@@ -243,9 +243,15 @@ function request(context, json, callback)
     console.log("packetId++");  // TEMP LOG - we are seeing this though...
     context.packetId++
 
+    console.log("requestQueue length: " + context.requestQueue.length);
+    for(var i = 0; i < context.requestQueue.length; i++){
+        console.log("requestQueue item " + (i + 1) + " json: " + JSON.stringify(context.requestQueue.json));
+    }
+
     console.log("request().s2sRequest()");  // TEMP LOG - and this...
     s2sRequest(context, packet, (context, data) =>
     {
+        console.log("request.s2sRequest() callback");   // TEMP LOG
         if (data && data.status != 200 && data.reason_code === SERVER_SESSION_EXPIRED && context.retryCount < 3)
         {
             console.log("if (data && data.status != 200 && data.reason_code === SERVER_SESSION_EXPIRED && context.retryCount < 3)");    // TEMP LOG
@@ -258,9 +264,11 @@ function request(context, json, callback)
             return
         }
 
+        /*
         console.log("context.requestQueue.splice"); // TEMP LOG
         context.requestQueue.splice(0, 1); // Remove this request
         context.retryCount = 0;
+        */
 
         if (callback)
         {
@@ -276,6 +284,11 @@ function request(context, json, callback)
                 callback(context, data)
             }
         }
+
+        // Copied here
+        console.log("context.requestQueue.splice"); // TEMP LOG
+        context.requestQueue.splice(0, 1); // Remove this request
+        context.retryCount = 0;
         
         // Do next request in queue
         console.log("Do next request in queue");    // TEMP LOG
@@ -286,8 +299,6 @@ function request(context, json, callback)
             request(context, nextRequest.json, nextRequest.callback)
         }
     })
-
-    console.log("End of request()");    // TEMP LOG
 }
 
 /*

--- a/brainclouds2s.js
+++ b/brainclouds2s.js
@@ -223,9 +223,16 @@ function request(context, json, callback) {
 }
 
 function callCallback(callback, context, data) {
-    
-    // TODO:  see s2s-java
-    callback(context, data);
+    if (callback != null) {
+        try {
+            callback(context, data);
+        }
+        catch (error) {
+            if (context.logEnabled) {
+                console.log(`[S2S Error ${context.appId}] ${error}`)
+            }
+        }
+    }
 }
 
 /*

--- a/brainclouds2s.js
+++ b/brainclouds2s.js
@@ -5,17 +5,15 @@ var util = require('util')
 const SERVER_SESSION_EXPIRED = 40365          // Error code for expired session
 const HEARTBEAT_INTERVALE_MS = 60 * 30 * 1000 // 30 minutes heartbeat interval
 
-const STATE_DISCONNECTED     = 0
-const STATE_AUTHENTICATING   = 1
-const STATE_CONNECTED        = 2
+const STATE_DISCONNECTED = 0
+const STATE_AUTHENTICATING = 1
+const STATE_CONNECTED = 2
 
 // Execute the S2S request
-function s2sRequest(context, json, callback)
-{
+function s2sRequest(context, json, callback) {
     var postData = JSON.stringify(json)
 
-    if (context.logEnabled)
-    {
+    if (context.logEnabled) {
         console.log(`[S2S SEND ${context.appId}] ${postData}`)
     }
 
@@ -29,60 +27,47 @@ function s2sRequest(context, json, callback)
         }
     }
 
-    var req = https.request(options, res =>
-    {
+    var req = https.request(options, res => {
         var data = ''
-        
+
         // A chunk of data has been recieved.
-        res.on('data', chunk =>
-        {
+        res.on('data', chunk => {
             data += chunk
         })
-        
+
         // The whole response has been received. Print out the result.
-        res.on('end', () =>
-        {
-            if (context.logEnabled)
-            {
+        res.on('end', () => {
+            if (context.logEnabled) {
                 console.log(`[S2S RECV ${context.appId}] ${data}`)
             }
-            if (callback)
-            {
-                if (data)
-                {
-                    
+            if (callback) {
+                if (data) {
+
                     try {
                         let dataJson = JSON.parse(data)
-                        callback(context, dataJson)
-                    } 
-                    catch (error) 
-                    {
-                        if (context.logEnabled)
-                        {
+                        callCallback(callback, context, dataJson)
+                    }
+                    catch (error) {
+                        if (context.logEnabled) {
                             console.log(`[S2S Error ${context.appId}] ${error}`)
                         }
-                        if (callback)
-                        {
-                            callback(context, null)
+                        if (callback) {
+                            callCallback(callback, context, null)
                         }
                     }
-                    
+
                 }
-                else
-                {
-                    callback(context, null)
+                else {
+                    callCallback(callback, context, null)
                 }
             }
         })
-    }).on("error", err =>
-    {
-        if (context.logEnabled)
-        {
+    }).on("error", err => {
+        if (context.logEnabled) {
             console.log(`[S2S Error ${context.appId}] ${err.message}`)
         }
-        if (callback)
-        {
-            callback(context, null)
+        if (callback) {
+            callCallback(callback, context, null)
         }
     })
 
@@ -91,39 +76,31 @@ function s2sRequest(context, json, callback)
     req.end()
 }
 
-function startHeartbeat(context)
-{
+function startHeartbeat(context) {
     stopHeartbeat(context)
-    context.heartbeatInternalId = setInterval(() =>
-    {
-        if (context.logEnabled)
-        {    
+    context.heartbeatInternalId = setInterval(() => {
+        if (context.logEnabled) {
             console.log("Heartbeat")
         }
         request(context, {
             service: "heartbeat",
             operation: "HEARTBEAT"
-        }, (context, data) =>
-        {
-            if (!(data && data.status === 200))
-            {
+        }, (context, data) => {
+            if (!(data && data.status === 200)) {
                 exports.disconnect(context)
             }
         })
     }, HEARTBEAT_INTERVALE_MS)
 }
 
-function stopHeartbeat(context)
-{
-    if (context.heartbeatInternalId)
-    {
+function stopHeartbeat(context) {
+    if (context.heartbeatInternalId) {
         clearInterval(context.heartbeatInternalId)
         context.heartbeatInternalId = null
     }
 }
 
-function authenticateInternal(context, callback)
-{
+function authenticateInternal(context, callback) {
     packetId = 0
     context.state = STATE_AUTHENTICATING;
 
@@ -142,48 +119,39 @@ function authenticateInternal(context, callback)
         ]
     }
 
-    s2sRequest(context, json, (context, data) =>
-    {
-        if (data && data.messageResponses && data.messageResponses.length > 0)
-        {
+    s2sRequest(context, json, (context, data) => {
+        if (data && data.messageResponses && data.messageResponses.length > 0) {
             let message = data.messageResponses[0]
 
-            if (data.messageResponses[0].status === 200)
-            {
-                context.state       = STATE_CONNECTED
-                context.packetId    = data.packetId + 1
-                context.sessionId   = message.data.sessionId
+            if (data.messageResponses[0].status === 200) {
+                context.state = STATE_CONNECTED
+                context.packetId = data.packetId + 1
+                context.sessionId = message.data.sessionId
 
                 // Start heartbeat
                 startHeartbeat(context)
             }
-            else
-            {
+            else {
                 failAllRequests(context, message);
             }
 
             if (callback)
-                callback(context, message)
+                callCallback(callback, context, message)
         }
-        else
-        {
+        else {
             failAllRequests(context, null);
             exports.disconnect(context)
             if (callback)
-                callback(context, null)
+                callCallback(callback, context, null)
         }
     })
 }
 
-function reAuth(context)
-{
-    authenticateInternal(context, (context, data) =>
-    {
-        if (data)
-        {
-            context.requestQueue.push({json: json, callback:callback});
-            if (context.requestQueue.length > 0)
-            {
+function reAuth(context) {
+    authenticateInternal(context, (context, data) => {
+        if (data) {
+            context.requestQueue.push({ json: json, callback: callback });
+            if (context.requestQueue.length > 0) {
                 let nextRequest = context.requestQueue[0];
                 request(context, nextRequest.json, nextRequest.callback)
             }
@@ -191,35 +159,29 @@ function reAuth(context)
     })
 }
 
-function queueRequest(context, json, callback)
-{
-    context.requestQueue.push({json: json, callback:callback});
+function queueRequest(context, json, callback) {
+    context.requestQueue.push({ json: json, callback: callback });
 
     // If only 1 in the queue, then send the request immediately
     // Also make sure we're not in the process of authenticating
-    if (context.requestQueue.length == 1 && 
-        context.state != STATE_AUTHENTICATING)
-    {
+    if (context.requestQueue.length == 1 &&
+        context.state != STATE_AUTHENTICATING) {
         request(context, json, callback)
     }
 }
 
-function failAllRequests(context, message)
-{
+function failAllRequests(context, message) {
     // Callback to all queued messages
     let requestQueue = context.requestQueue;
     context.requestQueue = [];
-    for (let request in context.requestQueue)
-    {
-        if (request.callback)
-        {
-            request.callback(context, message);
+    for (let request in context.requestQueue) {
+        if (request.callback) {
+            callCallback(request.callback, context, message);
         }
     }
 }
 
-function request(context, json, callback)
-{
+function request(context, json, callback) {
     let packet = {
         packetId: context.packetId,
         sessionId: context.sessionId,
@@ -228,10 +190,8 @@ function request(context, json, callback)
 
     context.packetId++
 
-    s2sRequest(context, packet, (context, data) =>
-    {
-        if (data && data.status != 200 && data.reason_code === SERVER_SESSION_EXPIRED && context.retryCount < 3)
-        {
+    s2sRequest(context, packet, (context, data) => {
+        if (data && data.status != 200 && data.reason_code === SERVER_SESSION_EXPIRED && context.retryCount < 3) {
             stopHeartbeat(context)
             context.authenticated = false
             context.retryCount++
@@ -241,29 +201,31 @@ function request(context, json, callback)
             return
         }
 
-        if (callback)
-        {
-            if (data && data.messageResponses && data.messageResponses.length > 0)
-            {
-                callback(context, data.messageResponses[0])
+        if (callback) {
+            if (data && data.messageResponses && data.messageResponses.length > 0) {
+                callCallback(callback, context, data.messageResponses[0]) // TODO:  callCallback
             }
-            else
-            {
+            else {
                 // Error that has no packets
-                callback(context, data)
+                callCallback(callback, context, data) // TODO:  callCallback
             }
         }
 
         context.requestQueue.splice(0, 1); // Remove this request from the queue
         context.retryCount = 0;
-        
+
         // Do next request in queue
-        if (context.requestQueue.length > 0)
-        {
+        if (context.requestQueue.length > 0) {
             let nextRequest = context.requestQueue[0];
             request(context, nextRequest.json, nextRequest.callback)
         }
     })
+}
+
+function callCallback(callback, context, data) {
+    
+    // TODO:  see s2s-java
+    callback(context, data);
 }
 
 /*
@@ -284,10 +246,8 @@ function request(context, json, callback)
  *                 before proceeding with other requests.
  * @return A new S2S context
  */
-exports.init = (appId, serverName, serverSecret, url, autoAuth) =>
-{
-    if (!url)
-    {
+exports.init = (appId, serverName, serverSecret, url, autoAuth) => {
+    if (!url) {
         url = "api.braincloudservers.com"
     }
 
@@ -311,8 +271,7 @@ exports.init = (appId, serverName, serverSecret, url, autoAuth) =>
  * Force disconnect a S2S session
  * @param context S2S context object returned by init
  */
-exports.disconnect = context =>
-{
+exports.disconnect = context => {
     stopHeartbeat(context)
     context.state = STATE_DISCONNECTED
     context.retryCount = 0
@@ -326,8 +285,7 @@ exports.disconnect = context =>
  * @param context S2S context object returned by init
  * @param enabled Will log if true. Default false
  */
-exports.setLogEnabled = (context, enabled) =>
-{
+exports.setLogEnabled = (context, enabled) => {
     context.logEnabled = enabled
 }
 
@@ -336,8 +294,7 @@ exports.setLogEnabled = (context, enabled) =>
  * @param context S2S context object returned by init
  * @param callback Callback function with signature: (context, result)
  */
-exports.authenticate = (context, callback) =>
-{
+exports.authenticate = (context, callback) => {
     authenticateInternal(context, callback)
 }
 
@@ -347,17 +304,12 @@ exports.authenticate = (context, callback) =>
  * @param json Content object to be sent
  * @param callback Callback function with signature: (context, result)
  */
-exports.request = (context, json, callback) =>
-{
-    if (context.state == STATE_DISCONNECTED && context.autoAuth)
-    {
-        authenticateInternal(context, (context, result) =>
-        {
-            if (context.state == STATE_CONNECTED && 
-                result && result.status == 200)
-            {
-                if (context.requestQueue.length > 0)
-                {
+exports.request = (context, json, callback) => {
+    if (context.state == STATE_DISCONNECTED && context.autoAuth) {
+        authenticateInternal(context, (context, result) => {
+            if (context.state == STATE_CONNECTED &&
+                result && result.status == 200) {
+                if (context.requestQueue.length > 0) {
                     let nextRequest = context.requestQueue[0];
                     request(context, nextRequest.json, nextRequest.callback)
                 }

--- a/brainclouds2s.js
+++ b/brainclouds2s.js
@@ -2,8 +2,8 @@ var https = require('https')
 var util = require('util')
 
 // Constants
-const SERVER_SESSION_EXPIRED = 40365          // Error code for expired session
-const HEARTBEAT_INTERVALE_MS = 60 * 30 * 1000 // 30 minutes heartbeat interval
+const SERVER_SESSION_EXPIRED = 40365    // Error code for expired session
+const HEARTBEAT_INTERVALE_MS = 60 * 30 * 1000   // 30 minutes heartbeat interval
 
 const STATE_DISCONNECTED = 0
 const STATE_AUTHENTICATING = 1
@@ -203,11 +203,11 @@ function request(context, json, callback) {
 
         if (callback) {
             if (data && data.messageResponses && data.messageResponses.length > 0) {
-                callCallback(callback, context, data.messageResponses[0]) // TODO:  callCallback
+                callCallback(callback, context, data.messageResponses[0])
             }
             else {
                 // Error that has no packets
-                callCallback(callback, context, data) // TODO:  callCallback
+                callCallback(callback, context, data)
             }
         }
 
@@ -222,6 +222,12 @@ function request(context, json, callback) {
     })
 }
 
+/**
+ * Invoke a given callback.
+ * @param callback Function to be executed
+ * @param context S2S context object
+ * @param data Content object to be sent
+ */
 function callCallback(callback, context, data) {
     if (callback != null) {
         try {

--- a/brainclouds2s.js
+++ b/brainclouds2s.js
@@ -171,6 +171,7 @@ function queueRequest(context, json, callback) {
 }
 
 function failAllRequests(context, message) {
+    
     // Callback to all queued messages
     let requestQueue = context.requestQueue;
     context.requestQueue = [];
@@ -206,11 +207,13 @@ function request(context, json, callback) {
                 callCallback(callback, context, data.messageResponses[0])
             }
             else {
+                
                 // Error that has no packets
                 callCallback(callback, context, data)
             }
         }
 
+        // This request is complete and safe to remove from queue after checking for callback
         context.requestQueue.splice(0, 1); // Remove this request from the queue
         context.retryCount = 0;
 
@@ -234,9 +237,7 @@ function callCallback(callback, context, data) {
             callback(context, data);
         }
         catch (error) {
-            if (context.logEnabled) {
-                console.log(`[S2S Error ${context.appId}] ${error}`)
-            }
+            console.log(`[S2S Error ${context.appId}] ${error}`)
         }
     }
 }

--- a/brainclouds2s.js
+++ b/brainclouds2s.js
@@ -12,12 +12,11 @@ const STATE_CONNECTED        = 2
 // Execute the S2S request
 function s2sRequest(context, json, callback)
 {
-    console.log("s2sRequest()");    // TEMP LOG
     var postData = JSON.stringify(json)
 
     if (context.logEnabled)
     {
-        console.log(`[S2S SENDING    ${context.appId}] ${postData}`)
+        console.log(`[S2S SEND ${context.appId}] ${postData}`)
     }
 
     var options = {
@@ -37,7 +36,6 @@ function s2sRequest(context, json, callback)
         // A chunk of data has been recieved.
         res.on('data', chunk =>
         {
-            console.log("res.on('data')");  // TEMP LOG
             data += chunk
         })
         
@@ -46,22 +44,19 @@ function s2sRequest(context, json, callback)
         {
             if (context.logEnabled)
             {
-                console.log(`[S2S RCV ${context.appId}] ${data}`)
+                console.log(`[S2S ReCV ${context.appId}] ${data}`)
             }
             if (callback)
             {
-                console.log("if (callback)");   // TEMP LOG
                 if (data)
                 {
                     
                     try {
-                        console.log("try callback");    // TEMP LOG
                         let dataJson = JSON.parse(data)
                         callback(context, dataJson)
                     } 
                     catch (error) 
                     {
-                        console.log("catch (error)");   // TEMP LOG
                         if (context.logEnabled)
                         {
                             console.log(`[S2S Error ${context.appId}] ${error}`)
@@ -75,7 +70,6 @@ function s2sRequest(context, json, callback)
                 }
                 else
                 {
-                    console.log("else { callback"); // TEMP LOG
                     callback(context, null)
                 }
             }
@@ -130,7 +124,6 @@ function stopHeartbeat(context)
 
 function authenticateInternal(context, callback)
 {
-    console.log("authenticateInternal()");  // TEMP LOG
     packetId = 0
     context.state = STATE_AUTHENTICATING;
 
@@ -184,12 +177,10 @@ function authenticateInternal(context, callback)
 
 function reAuth(context)
 {
-    console.log("reAuth()");    // TEMP LOG
     authenticateInternal(context, (context, data) =>
     {
         if (data)
         {
-            console.log("context.requestQueue push"); // TEMP LOG
             context.requestQueue.push({json: json, callback:callback});
             if (context.requestQueue.length > 0)
             {
@@ -202,17 +193,13 @@ function reAuth(context)
 
 function queueRequest(context, json, callback)
 {
-    console.log("queueRequest()");  // TEMP LOG
-    console.log("requestQueue length pre push: " + context.requestQueue.length + " now push()");
     context.requestQueue.push({json: json, callback:callback});
-    console.log("requestQueue length after push: " + context.requestQueue.length);
 
     // If only 1 in the queue, then send the request immediately
     // Also make sure we're not in the process of authenticating
     if (context.requestQueue.length == 1 && 
         context.state != STATE_AUTHENTICATING)
     {
-        console.log("context.requestQueue.length == 1");    // TEMP LOG
         request(context, json, callback)
     }
 }
@@ -233,28 +220,18 @@ function failAllRequests(context, message)
 
 function request(context, json, callback)
 {
-    console.log("request()");   // TEMP LOG - we aren't seeing this... why??
     let packet = {
         packetId: context.packetId,
         sessionId: context.sessionId,
         messages: [json]
     }
 
-    console.log("packetId++");  // TEMP LOG - we are seeing this though...
     context.packetId++
 
-    console.log("requestQueue length: " + context.requestQueue.length);
-    for(var i = 0; i < context.requestQueue.length; i++){
-        console.log("requestQueue item " + (i + 1) + " json: " + JSON.stringify(context.requestQueue.json));
-    }
-
-    console.log("request().s2sRequest()");  // TEMP LOG - and this...
     s2sRequest(context, packet, (context, data) =>
     {
-        console.log("request.s2sRequest() callback");   // TEMP LOG
         if (data && data.status != 200 && data.reason_code === SERVER_SESSION_EXPIRED && context.retryCount < 3)
         {
-            console.log("if (data && data.status != 200 && data.reason_code === SERVER_SESSION_EXPIRED && context.retryCount < 3)");    // TEMP LOG
             stopHeartbeat(context)
             context.authenticated = false
             context.retryCount++
@@ -264,37 +241,25 @@ function request(context, json, callback)
             return
         }
 
-        /*
-        console.log("context.requestQueue.splice"); // TEMP LOG
-        context.requestQueue.splice(0, 1); // Remove this request
-        context.retryCount = 0;
-        */
-
         if (callback)
         {
             if (data && data.messageResponses && data.messageResponses.length > 0)
             {
-                console.log("if (data && data.messageResponses && data.messageResponses.length > 0)");    // TEMP LOG
                 callback(context, data.messageResponses[0])
             }
             else
             {
                 // Error that has no packets
-                console.log("Error that has no packets");    // TEMP LOG
                 callback(context, data)
             }
         }
 
-        // Copied here
-        console.log("context.requestQueue.splice"); // TEMP LOG
-        context.requestQueue.splice(0, 1); // Remove this request
+        context.requestQueue.splice(0, 1); // Remove this request from the queue
         context.retryCount = 0;
         
         // Do next request in queue
-        console.log("Do next request in queue");    // TEMP LOG
         if (context.requestQueue.length > 0)
         {
-            console.log("if context.requestQueue.length > 0");  // TEMP LOG
             let nextRequest = context.requestQueue[0];
             request(context, nextRequest.json, nextRequest.callback)
         }
@@ -384,10 +349,8 @@ exports.authenticate = (context, callback) =>
  */
 exports.request = (context, json, callback) =>
 {
-    console.log("exports.request()");   // TEMP LOG
     if (context.state == STATE_DISCONNECTED && context.autoAuth)
     {
-        console.log("context.state == STATE_DISCONNECTED"); // TEMP LOG
         authenticateInternal(context, (context, result) =>
         {
             if (context.state == STATE_CONNECTED && 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "brainclouds2s",
   "version": "4.15.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "brainclouds2s",
+      "version": "4.15.0",
+      "license": "ISC"
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brainclouds2s",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brainclouds2s",
-      "version": "4.15.0",
+      "version": "4.15.1",
       "license": "ISC"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainclouds2s",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "description": "brianCloud S2S module",
   "main": "brainclouds2s.js",
   "scripts": {


### PR DESCRIPTION
- removing request from queue was happening before the request had a chance to complete processing, resulting in some requests being sent twice by mistake
   - removal now happens **after** the request's callback has been executed
- added helper function to handle callback exceptions
- adjusted formatting 